### PR TITLE
feat(gateway): add unified MCP gateway with per-domain enable/disable

### DIFF
--- a/mcp/cesium-js/README.md
+++ b/mcp/cesium-js/README.md
@@ -13,6 +13,7 @@ pnpm monorepo containing MCP servers and test applications for controlling [Cesi
 | [`@cesium-mcp/imagery-server`](./servers/imagery-server/README.md)              | Imagery layer management: add, remove, and list imagery providers                    | 3005 |
 | [`@cesium-mcp/tiles-server`](./servers/tiles-server/README.md)                  | 3D Tiles management: add, remove, and configure 3D Tilesets                          | 3006 |
 | [`@cesium-mcp/terrain-server`](./servers/terrain-server/README.md)              | Terrain provider management: set, get, and remove terrain sources                    | 3007 |
+| [`@cesium-mcp/gateway`](./servers/gateway/README.md)                            | Unified gateway aggregating multiple domain servers with runtime enable/disable      | 3010 |
 | [`@cesium-mcp/client-core`](./test-applications/packages/client-core/README.md) | Shared browser client library (managers, communications)                             | —    |
 | [`@cesium-mcp/cesium-js`](./test-applications/README.md)                        | Browser web application (CesiumJS viewer)                                            | 8080 |
 
@@ -88,6 +89,18 @@ Manage terrain providers on the CesiumJS globe.
 | `terrain_get`    | Get current terrain provider info and capabilities  |
 | `terrain_remove` | Remove terrain and reset to flat WGS84 ellipsoid    |
 
+### 🧭 [cesium-gateway](./servers/gateway/README.md)
+
+Unified gateway that aggregates multiple domain servers behind a single MCP endpoint and exposes meta-tools for runtime domain discovery. Helps keep the active tool surface small when many servers would otherwise be connected at once.
+
+| Tool                     | Description                                                   |
+| ------------------------ | ------------------------------------------------------------- |
+| `gateway_list_domains`   | List all domains with enabled/disabled status and tool counts |
+| `gateway_enable_domain`  | Enable all tools in a domain at runtime                       |
+| `gateway_disable_domain` | Disable all tools in a domain at runtime                      |
+
+The set of domains started at boot is controlled by the `GATEWAY_DOMAINS` environment variable (comma-separated, case-insensitive; omitted or empty means enable all).
+
 ## 🏗️ Structure
 
 ```
@@ -99,7 +112,8 @@ cesium-js/
 │   ├── animation-server/    # @cesium-mcp/animation-server
 │   ├── imagery-server/      # @cesium-mcp/imagery-server
 │   ├── tiles-server/        # @cesium-mcp/tiles-server
-│   └── terrain-server/      # @cesium-mcp/terrain-server
+│   ├── terrain-server/      # @cesium-mcp/terrain-server
+│   └── gateway/             # @cesium-mcp/gateway
 ├── test-applications/
 │   ├── packages/
 │   │   └── client-core/     # @cesium-mcp/client-core
@@ -136,6 +150,7 @@ pnpm run build:animation    # @cesium-mcp/animation-server only
 pnpm run build:imagery      # @cesium-mcp/imagery-server only
 pnpm run build:tiles        # @cesium-mcp/tiles-server only
 pnpm run build:terrain      # @cesium-mcp/terrain-server only
+pnpm run build:gateway      # @cesium-mcp/gateway only
 pnpm run build:cesium-js    # @cesium-mcp/cesium-js (web app) only
 pnpm run clean              # Remove all build artifacts
 ```
@@ -151,6 +166,7 @@ pnpm run dev:animation     # Animation server on port 3004
 pnpm run dev:imagery       # Imagery server on port 3005
 pnpm run dev:tiles         # Tiles server on port 3006
 pnpm run dev:terrain       # Terrain server on port 3007
+pnpm run dev:gateway       # Gateway on port 3010
 ```
 
 ### Web Application
@@ -231,6 +247,16 @@ Add the servers to your MCP client (e.g., Claude Desktop, Cline):
       "env": {
         "COMMUNICATION_PROTOCOL": "websocket",
         "TERRAIN_SERVER_PORT": "3007",
+        "STRICT_PORT": "false"
+      }
+    },
+    "cesium-gateway": {
+      "command": "node",
+      "args": ["{YOUR_WORKSPACE}/mcp/cesium-js/servers/gateway/build/index.js"],
+      "env": {
+        "COMMUNICATION_PROTOCOL": "websocket",
+        "GATEWAY_SERVER_PORT": "3010",
+        "GATEWAY_DOMAINS": "camera,entity,animation,imagery,tiles,terrain",
         "STRICT_PORT": "false"
       }
     }

--- a/mcp/cesium-js/README.md
+++ b/mcp/cesium-js/README.md
@@ -93,13 +93,13 @@ Manage terrain providers on the CesiumJS globe.
 
 Unified gateway that aggregates multiple domain servers behind a single MCP endpoint and exposes meta-tools for runtime domain discovery. Helps keep the active tool surface small when many servers would otherwise be connected at once.
 
-| Tool                     | Description                                                   |
-| ------------------------ | ------------------------------------------------------------- |
-| `gateway_list_domains`   | List all domains with enabled/disabled status and tool counts |
-| `gateway_enable_domain`  | Enable all tools in a domain at runtime                       |
-| `gateway_disable_domain` | Disable all tools in a domain at runtime                      |
+| Tool                    | Description                                                   |
+| ----------------------- | ------------------------------------------------------------- |
+| `cesium_list_domains`   | List all domains with enabled/disabled status and tool counts |
+| `cesium_enable_domain`  | Enable all tools in a domain at runtime                       |
+| `cesium_disable_domain` | Disable all tools in a domain at runtime                      |
 
-The set of domains started at boot is controlled by the `GATEWAY_DOMAINS` environment variable (comma-separated, case-insensitive; omitted or empty means enable all).
+The set of domains started at boot is controlled by the `CESIUM_DOMAINS` environment variable (comma-separated, case-insensitive; omitted or empty means enable all).
 
 ## 🏗️ Structure
 

--- a/mcp/cesium-js/package.json
+++ b/mcp/cesium-js/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm run build:shared && pnpm run build:camera && pnpm run build:entity && pnpm run build:animation && pnpm run build:imagery && pnpm run build:tiles && pnpm run build:terrain && pnpm run build:cesium-js",
+    "build": "pnpm run build:shared && pnpm run build:camera && pnpm run build:entity && pnpm run build:animation && pnpm run build:imagery && pnpm run build:tiles && pnpm run build:terrain && pnpm run build:gateway && pnpm run build:cesium-js",
     "build:shared": "pnpm --filter @cesium-mcp/shared build",
     "build:camera": "pnpm --filter @cesium-mcp/camera-server build",
     "build:entity": "pnpm --filter @cesium-mcp/entity-server build",
@@ -13,6 +13,7 @@
     "build:imagery": "pnpm --filter @cesium-mcp/imagery-server build",
     "build:tiles": "pnpm --filter @cesium-mcp/tiles-server build",
     "build:terrain": "pnpm --filter @cesium-mcp/terrain-server build",
+    "build:gateway": "pnpm --filter @cesium-mcp/gateway build",
     "build:cesium-js": "pnpm --filter @cesium-mcp/cesium-js build",
     "dev:camera": "pnpm --filter @cesium-mcp/camera-server dev",
     "dev:entity": "pnpm --filter @cesium-mcp/entity-server dev",
@@ -20,6 +21,7 @@
     "dev:imagery": "pnpm --filter @cesium-mcp/imagery-server dev",
     "dev:tiles": "pnpm --filter @cesium-mcp/tiles-server dev",
     "dev:terrain": "pnpm --filter @cesium-mcp/terrain-server dev",
+    "dev:gateway": "pnpm --filter @cesium-mcp/gateway dev",
     "start:web": "pnpm --filter @cesium-mcp/cesium-js start:web",
     "clean": "pnpm -r run clean",
     "lint": "eslint .",
@@ -34,7 +36,8 @@
     "test:animation": "pnpm --filter @cesium-mcp/animation-server test",
     "test:imagery": "pnpm --filter @cesium-mcp/imagery-server test",
     "test:tiles": "pnpm --filter @cesium-mcp/tiles-server test",
-    "test:terrain": "pnpm --filter @cesium-mcp/terrain-server test"
+    "test:terrain": "pnpm --filter @cesium-mcp/terrain-server test",
+    "test:gateway": "pnpm --filter @cesium-mcp/gateway test"
   },
   "keywords": [
     "mcp",

--- a/mcp/cesium-js/pnpm-lock.yaml
+++ b/mcp/cesium-js/pnpm-lock.yaml
@@ -159,6 +159,58 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.3.3)(@vitest/ui@4.0.18)(tsx@4.21.0)
 
+  servers/gateway:
+    dependencies:
+      '@cesium-mcp/animation-server':
+        specifier: workspace:*
+        version: link:../animation-server
+      '@cesium-mcp/camera-server':
+        specifier: workspace:*
+        version: link:../camera-server
+      '@cesium-mcp/entity-server':
+        specifier: workspace:*
+        version: link:../entity-server
+      '@cesium-mcp/imagery-server':
+        specifier: workspace:*
+        version: link:../imagery-server
+      '@cesium-mcp/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@cesium-mcp/terrain-server':
+        specifier: workspace:*
+        version: link:../terrain-server
+      '@cesium-mcp/tiles-server':
+        specifier: workspace:*
+        version: link:../tiles-server
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.27.1(zod@4.3.6)
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.3.3
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18)
+      '@vitest/ui':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.3.3)(@vitest/ui@4.0.18)(tsx@4.21.0)
+
   servers/imagery-server:
     dependencies:
       '@cesium-mcp/shared':

--- a/mcp/cesium-js/servers/animation-server/package.json
+++ b/mcp/cesium-js/servers/animation-server/package.json
@@ -4,6 +4,10 @@
   "description": "MCP server for Cesium animation, path-based entity control, and clock management",
   "type": "module",
   "main": "build/index.js",
+  "exports": {
+    ".": "./build/index.js",
+    "./tools": "./build/tools/index.js"
+  },
   "bin": {
     "cesium-animation-mcp": "./build/index.js"
   },

--- a/mcp/cesium-js/servers/camera-server/package.json
+++ b/mcp/cesium-js/servers/camera-server/package.json
@@ -24,7 +24,8 @@
   ],
   "license": "Apache-2.0",
   "exports": {
-    ".": "./build/index.js"
+    ".": "./build/index.js",
+    "./tools": "./build/tools/index.js"
   },
   "dependencies": {
     "@cesium-mcp/shared": "workspace:*",

--- a/mcp/cesium-js/servers/entity-server/package.json
+++ b/mcp/cesium-js/servers/entity-server/package.json
@@ -9,7 +9,8 @@
   },
   "exports": {
     ".": "./build/index.js",
-    "./schemas": "./build/schemas.js"
+    "./schemas": "./build/schemas.js",
+    "./tools": "./build/tools/index.js"
   },
   "scripts": {
     "build": "tsc",

--- a/mcp/cesium-js/servers/gateway/.env.example
+++ b/mcp/cesium-js/servers/gateway/.env.example
@@ -1,0 +1,8 @@
+PORT=3010
+MAX_RETRIES=10
+COMMUNICATION_PROTOCOL=websocket
+STRICT_PORT=false
+MCP_TRANSPORT=stdio
+# Comma-separated list of domains to enable at startup. Leave empty or omit to enable all.
+# Valid values: camera, entity, animation, imagery, tiles, terrain
+# CESIUM_DOMAINS=camera,entity,animation,imagery,tiles,terrain

--- a/mcp/cesium-js/servers/gateway/README.md
+++ b/mcp/cesium-js/servers/gateway/README.md
@@ -1,0 +1,100 @@
+# Cesium Gateway MCP Server
+
+A unified MCP server that aggregates all Cesium domain servers (camera, entity, animation, imagery, tiles, terrain) into a single endpoint with dynamic domain management.
+
+## Features
+
+- **Single endpoint** — one MCP server exposes all domain tools
+- **Domain filtering** — enable only the domains you need via `CESIUM_DOMAINS`
+- **Runtime control** — dynamically enable/disable domains with discovery tools
+- **Shared communication** — all domains share one WebSocket/SSE connection to the browser
+
+## Quick Start
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build
+pnpm run build
+
+# Run
+pnpm start
+```
+
+## Configuration
+
+| Variable                 | Default     | Description                               |
+| ------------------------ | ----------- | ----------------------------------------- |
+| `PORT`                   | `3010`      | Communication server port                 |
+| `CESIUM_DOMAINS`         | _(all)_     | Comma-separated list of domains to enable |
+| `COMMUNICATION_PROTOCOL` | `websocket` | `websocket` or `sse`                      |
+| `MCP_TRANSPORT`          | `stdio`     | `stdio` or `streamable-http`              |
+| `MAX_RETRIES`            | `10`        | Max retries for communication server port |
+| `STRICT_PORT`            | `false`     | Fail if port is already in use            |
+
+### Domain Selection
+
+```bash
+# Enable all domains (default)
+CESIUM_DOMAINS=
+
+# Enable only camera and entity
+CESIUM_DOMAINS=camera,entity
+
+# Available domains: camera, entity, animation, imagery, tiles, terrain
+```
+
+## MCP Client Configuration
+
+### Claude Desktop / Cursor
+
+```json
+{
+  "mcpServers": {
+    "cesium-gateway": {
+      "command": "node",
+      "args": ["path/to/servers/gateway/build/index.js"],
+      "env": {
+        "PORT": "3010",
+        "CESIUM_DOMAINS": "camera,entity,animation,imagery,tiles,terrain"
+      }
+    }
+  }
+}
+```
+
+## Discovery Tools
+
+The gateway exposes three meta-tools for runtime domain management:
+
+| Tool                    | Description                                                   |
+| ----------------------- | ------------------------------------------------------------- |
+| `cesium_list_domains`   | List all domains with enabled/disabled status and tool counts |
+| `cesium_enable_domain`  | Enable a previously disabled domain                           |
+| `cesium_disable_domain` | Disable a domain, hiding its tools                            |
+
+These tools use the MCP SDK's `RegisteredTool.enable()`/`disable()` API, so clients that support `tools/list_changed` notifications will see the tool list update in real time.
+
+## Architecture
+
+```
+MCP Client
+    │
+    ▼
+┌──────────────────────────────┐
+│     Gateway MCP Server       │
+│  ┌────────────────────────┐  │
+│  │   DomainRegistry       │  │
+│  │  ┌──────┐ ┌──────┐    │  │
+│  │  │camera│ │entity│ .. │  │
+│  │  └──────┘ └──────┘    │  │
+│  └────────────────────────┘  │
+│  ┌────────────────────────┐  │
+│  │   Discovery Tools      │  │
+│  └────────────────────────┘  │
+└──────────────┬───────────────┘
+               │ WebSocket/SSE
+               ▼
+         CesiumJS App
+```

--- a/mcp/cesium-js/servers/gateway/package.json
+++ b/mcp/cesium-js/servers/gateway/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cesium-mcp/imagery-server",
+  "name": "@cesium-mcp/gateway",
   "version": "1.0.0",
-  "description": "MCP server for Cesium imagery layer management operations",
+  "description": "Unified MCP gateway server that combines all Cesium domain servers into a single process",
   "type": "module",
   "main": "./build/index.js",
   "bin": {
-    "cesium-imagery-mcp": "./build/index.js"
+    "cesium-gateway-mcp": "./build/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -19,17 +19,22 @@
   "keywords": [
     "mcp",
     "cesium",
-    "imagery",
+    "gateway",
     "3d",
     "geospatial"
   ],
   "license": "Apache-2.0",
   "exports": {
-    ".": "./build/index.js",
-    "./tools": "./build/tools/index.js"
+    ".": "./build/index.js"
   },
   "dependencies": {
     "@cesium-mcp/shared": "workspace:*",
+    "@cesium-mcp/camera-server": "workspace:*",
+    "@cesium-mcp/entity-server": "workspace:*",
+    "@cesium-mcp/animation-server": "workspace:*",
+    "@cesium-mcp/imagery-server": "workspace:*",
+    "@cesium-mcp/tiles-server": "workspace:*",
+    "@cesium-mcp/terrain-server": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "dotenv": "^16.4.7",
     "zod": "^4.3.6"

--- a/mcp/cesium-js/servers/gateway/src/domain-registry.ts
+++ b/mcp/cesium-js/servers/gateway/src/domain-registry.ts
@@ -1,0 +1,138 @@
+import {
+  McpServer,
+  RegisteredTool,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ICommunicationServer } from "@cesium-mcp/shared";
+import { DomainDefinition } from "./domains.js";
+
+/**
+ * Tracks which RegisteredTool instances belong to each domain.
+ */
+export interface DomainState {
+  name: string;
+  tools: Map<string, RegisteredTool>;
+  enabled: boolean;
+}
+
+/**
+ * Registry that manages domain-to-tool mappings.
+ * Uses a proxy on McpServer.registerTool to intercept tool registrations
+ * and associate them with the current domain being registered.
+ */
+export class DomainRegistry {
+  private domains: Map<string, DomainState> = new Map();
+
+  /**
+   * Register a domain's tools by calling its registration function while
+   * intercepting all registerTool calls to track the resulting RegisteredTool objects.
+   */
+  registerDomain(
+    domain: DomainDefinition,
+    mcpServer: McpServer,
+    communicationServer: ICommunicationServer | undefined,
+  ): void {
+    const domainState: DomainState = {
+      name: domain.name,
+      tools: new Map(),
+      enabled: true,
+    };
+
+    // Wrap registerTool to capture the returned RegisteredTool.
+    // IMPORTANT: wrapped via try/finally so a throwing domain registration
+    // cannot permanently pollute mcpServer.registerTool.
+    // Note: registerTool has multiple overloads, so we type-erase args to unknown[]
+    // and cast the wrapper back to the original type — this is safe because we
+    // only forward arguments verbatim and return the original result.
+    // We keep the original reference for restoration, and use a bound copy
+    // for invocation (so `this` is preserved when calling through).
+    const originalRegisterTool = mcpServer.registerTool;
+    const boundOriginal = originalRegisterTool.bind(mcpServer);
+    const wrappedRegisterTool = ((...args: unknown[]) => {
+      const registeredTool = (
+        boundOriginal as (...a: unknown[]) => RegisteredTool
+      )(...args);
+      const name = args[0] as string;
+      domainState.tools.set(name, registeredTool);
+      return registeredTool;
+    }) as unknown as typeof mcpServer.registerTool;
+
+    mcpServer.registerTool = wrappedRegisterTool;
+    try {
+      domain.registerTools(mcpServer, communicationServer);
+    } finally {
+      // Always restore original registerTool, even if registration throws
+      mcpServer.registerTool = originalRegisterTool;
+    }
+
+    this.domains.set(domain.name, domainState);
+  }
+
+  /**
+   * Disable all tools in a domain.
+   */
+  disableDomain(name: string): boolean {
+    const domain = this.domains.get(name);
+    if (!domain) {
+      return false;
+    }
+    if (!domain.enabled) {
+      return true;
+    }
+
+    for (const tool of domain.tools.values()) {
+      tool.disable();
+    }
+    domain.enabled = false;
+    return true;
+  }
+
+  /**
+   * Enable all tools in a domain.
+   */
+  enableDomain(name: string): boolean {
+    const domain = this.domains.get(name);
+    if (!domain) {
+      return false;
+    }
+    if (domain.enabled) {
+      return true;
+    }
+
+    for (const tool of domain.tools.values()) {
+      tool.enable();
+    }
+    domain.enabled = true;
+    return true;
+  }
+
+  /**
+   * List all domains with their status.
+   */
+  listDomains(): Array<{
+    name: string;
+    enabled: boolean;
+    toolCount: number;
+    tools: string[];
+  }> {
+    return Array.from(this.domains.values()).map((d) => ({
+      name: d.name,
+      enabled: d.enabled,
+      toolCount: d.tools.size,
+      tools: Array.from(d.tools.keys()),
+    }));
+  }
+
+  /**
+   * Get a specific domain state.
+   */
+  getDomain(name: string): DomainState | undefined {
+    return this.domains.get(name);
+  }
+
+  /**
+   * Get all registered domain names.
+   */
+  getDomainNames(): string[] {
+    return Array.from(this.domains.keys());
+  }
+}

--- a/mcp/cesium-js/servers/gateway/src/domain-registry.ts
+++ b/mcp/cesium-js/servers/gateway/src/domain-registry.ts
@@ -68,41 +68,41 @@ export class DomainRegistry {
   }
 
   /**
-   * Disable all tools in a domain.
+   * Set the enabled state for all tools in a domain.
+   * Returns true if the domain exists, false otherwise.
    */
-  disableDomain(name: string): boolean {
+  private setDomainEnabled(name: string, enabled: boolean): boolean {
     const domain = this.domains.get(name);
     if (!domain) {
       return false;
     }
-    if (!domain.enabled) {
+    if (domain.enabled === enabled) {
       return true;
     }
 
     for (const tool of domain.tools.values()) {
-      tool.disable();
+      if (enabled) {
+        tool.enable();
+      } else {
+        tool.disable();
+      }
     }
-    domain.enabled = false;
+    domain.enabled = enabled;
     return true;
+  }
+
+  /**
+   * Disable all tools in a domain.
+   */
+  disableDomain(name: string): boolean {
+    return this.setDomainEnabled(name, false);
   }
 
   /**
    * Enable all tools in a domain.
    */
   enableDomain(name: string): boolean {
-    const domain = this.domains.get(name);
-    if (!domain) {
-      return false;
-    }
-    if (domain.enabled) {
-      return true;
-    }
-
-    for (const tool of domain.tools.values()) {
-      tool.enable();
-    }
-    domain.enabled = true;
-    return true;
+    return this.setDomainEnabled(name, true);
   }
 
   /**

--- a/mcp/cesium-js/servers/gateway/src/domains.ts
+++ b/mcp/cesium-js/servers/gateway/src/domains.ts
@@ -1,0 +1,58 @@
+import { ToolRegistrationFunction } from "@cesium-mcp/shared";
+import { registerCameraTools } from "@cesium-mcp/camera-server/tools";
+import { registerEntityTools } from "@cesium-mcp/entity-server/tools";
+import { registerAllAnimationTools } from "@cesium-mcp/animation-server/tools";
+import { registerImageryTools } from "@cesium-mcp/imagery-server/tools";
+import { registerTilesTools } from "@cesium-mcp/tiles-server/tools";
+import { registerTerrainTools } from "@cesium-mcp/terrain-server/tools";
+
+/**
+ * Domain definition mapping a domain name to its tool registration function.
+ */
+export interface DomainDefinition {
+  name: string;
+  registerTools: ToolRegistrationFunction;
+}
+
+/**
+ * All available domain definitions.
+ */
+export const ALL_DOMAINS: DomainDefinition[] = [
+  { name: "camera", registerTools: registerCameraTools },
+  { name: "entity", registerTools: registerEntityTools },
+  { name: "animation", registerTools: registerAllAnimationTools },
+  { name: "imagery", registerTools: registerImageryTools },
+  { name: "tiles", registerTools: registerTilesTools },
+  { name: "terrain", registerTools: registerTerrainTools },
+];
+
+/**
+ * All valid domain names.
+ */
+export const VALID_DOMAIN_NAMES = ALL_DOMAINS.map((d) => d.name);
+
+/**
+ * Filter domains by the CESIUM_DOMAINS environment variable.
+ * If not set or empty, returns all domains.
+ */
+export function getEnabledDomains(
+  envValue: string | undefined,
+): DomainDefinition[] {
+  if (!envValue || envValue.trim() === "") {
+    return ALL_DOMAINS;
+  }
+
+  const requested = envValue
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+
+  const invalid = requested.filter((r) => !VALID_DOMAIN_NAMES.includes(r));
+  if (invalid.length > 0) {
+    console.error(
+      `Warning: Unknown domain(s): ${invalid.join(", ")}. Valid domains: ${VALID_DOMAIN_NAMES.join(", ")}`,
+    );
+  }
+
+  return ALL_DOMAINS.filter((d) => requested.includes(d.name));
+}

--- a/mcp/cesium-js/servers/gateway/src/index.ts
+++ b/mcp/cesium-js/servers/gateway/src/index.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import "dotenv/config";
+import {
+  CesiumMCPServer,
+  CesiumSSEServer,
+  CesiumWebSocketServer,
+  ToolRegistrationFunction,
+} from "@cesium-mcp/shared";
+import { getEnabledDomains } from "./domains.js";
+import { DomainRegistry } from "./domain-registry.js";
+import { registerDiscoveryTools } from "./tools/discovery.js";
+
+const PORT = parseInt(
+  process.env.PORT || process.env.GATEWAY_SERVER_PORT || "3010",
+);
+const MAX_RETRIES = parseInt(process.env.MAX_RETRIES || "10");
+const PROTOCOL = process.env.COMMUNICATION_PROTOCOL || "websocket";
+const STRICT_PORT = process.env.STRICT_PORT === "true";
+
+async function main() {
+  try {
+    const communicationServer =
+      PROTOCOL === "sse" ? new CesiumSSEServer() : new CesiumWebSocketServer();
+
+    const registry = new DomainRegistry();
+    const domains = getEnabledDomains(process.env.CESIUM_DOMAINS);
+
+    if (domains.length === 0) {
+      console.error(
+        "No domains enabled. Set CESIUM_DOMAINS or remove it to enable all.",
+      );
+      process.exit(1);
+    }
+
+    // Single registration function that registers all domain tools + discovery tools
+    const gatewayRegistration: ToolRegistrationFunction = (
+      mcpServer,
+      commServer,
+    ) => {
+      for (const domain of domains) {
+        registry.registerDomain(domain, mcpServer, commServer);
+        console.error(`  Registered domain: ${domain.name}`);
+      }
+      // Register discovery tools (not intercepted — they belong to the gateway itself)
+      registerDiscoveryTools(mcpServer, registry);
+      console.error("  Registered discovery tools");
+    };
+
+    const server = new CesiumMCPServer(
+      {
+        name: "cesium-gateway-mcp-server",
+        version: "1.0.0",
+        communicationServerPort: PORT,
+        communicationServerMaxRetries: MAX_RETRIES,
+        communicationServerStrictPort: STRICT_PORT,
+        mcpTransport: (process.env.MCP_TRANSPORT || "stdio") as
+          | "stdio"
+          | "streamable-http",
+      },
+      communicationServer,
+    );
+
+    const domainNames = domains.map((d) => d.name).join(", ");
+    console.error(
+      `Gateway starting with ${PROTOCOL.toUpperCase()} on port ${PORT} (domains: ${domainNames})`,
+    );
+
+    server.registerTools(gatewayRegistration);
+    await server.start();
+  } catch (error) {
+    console.error("Failed to start gateway server:", error);
+    process.exit(1);
+  }
+}
+
+// Handle errors
+main().catch((error) => {
+  console.error("Fatal error in main():", error);
+  process.exit(1);
+});

--- a/mcp/cesium-js/servers/gateway/src/tools/discovery.ts
+++ b/mcp/cesium-js/servers/gateway/src/tools/discovery.ts
@@ -1,0 +1,117 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { DomainRegistry } from "../domain-registry.js";
+import { VALID_DOMAIN_NAMES } from "../domains.js";
+
+/**
+ * Register the gateway discovery tools (list, enable, disable domains).
+ */
+export function registerDiscoveryTools(
+  server: McpServer,
+  registry: DomainRegistry,
+): void {
+  // List all domains and their status
+  server.registerTool(
+    "cesium_list_domains",
+    {
+      title: "List Cesium Domains",
+      description:
+        "List all available Cesium tool domains with their enabled/disabled status and tool counts",
+    },
+    () => {
+      const domains = registry.listDomains();
+      const summary = domains
+        .map(
+          (d) =>
+            `${d.enabled ? "[ON]" : "[OFF]"} ${d.name} (${d.toolCount} tools)`,
+        )
+        .join("\n");
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Cesium Gateway Domains:\n\n${summary}\n\nTotal: ${domains.length} domains, ${domains.reduce((sum, d) => sum + d.toolCount, 0)} tools`,
+          },
+        ],
+      };
+    },
+  );
+
+  // Enable a domain
+  server.registerTool(
+    "cesium_enable_domain",
+    {
+      title: "Enable Cesium Domain",
+      description:
+        "Enable a previously disabled Cesium tool domain, making its tools available again",
+      inputSchema: {
+        domain: z
+          .enum(VALID_DOMAIN_NAMES as [string, ...string[]])
+          .describe("The domain to enable"),
+      },
+    },
+    ({ domain }: { domain: string }) => {
+      const success = registry.enableDomain(domain);
+      if (!success) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Domain "${domain}" not found. Available: ${registry.getDomainNames().join(", ")}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const state = registry.getDomain(domain);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Domain "${domain}" enabled. ${state?.tools.size ?? 0} tools are now available.`,
+          },
+        ],
+      };
+    },
+  );
+
+  // Disable a domain
+  server.registerTool(
+    "cesium_disable_domain",
+    {
+      title: "Disable Cesium Domain",
+      description:
+        "Disable a Cesium tool domain, hiding its tools from the tool list. Can be re-enabled later.",
+      inputSchema: {
+        domain: z
+          .enum(VALID_DOMAIN_NAMES as [string, ...string[]])
+          .describe("The domain to disable"),
+      },
+    },
+    ({ domain }: { domain: string }) => {
+      const success = registry.disableDomain(domain);
+      if (!success) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Domain "${domain}" not found. Available: ${registry.getDomainNames().join(", ")}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Domain "${domain}" disabled. Its tools are now hidden.`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/mcp/cesium-js/servers/gateway/test/domain-registry.test.ts
+++ b/mcp/cesium-js/servers/gateway/test/domain-registry.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  McpServer,
+  RegisteredTool,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ICommunicationServer } from "@cesium-mcp/shared";
+import { DomainRegistry } from "../src/domain-registry";
+import type { DomainDefinition } from "../src/domains";
+
+/**
+ * Build a minimal RegisteredTool stub with spy-able enable/disable.
+ */
+function makeTool(overrides: Partial<RegisteredTool> = {}): RegisteredTool {
+  return {
+    enabled: true,
+    enable: vi.fn(),
+    disable: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    handler: vi.fn(),
+    ...overrides,
+  } as unknown as RegisteredTool;
+}
+
+/**
+ * Build a mock McpServer whose registerTool returns a fresh tool stub
+ * and records the registered name.
+ */
+function makeServer() {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    registerTool: vi.fn((name: string) => {
+      const tool = makeTool();
+      tools.set(name, tool);
+      return tool;
+    }),
+  };
+  return { server: server as unknown as McpServer, tools };
+}
+
+describe("DomainRegistry", () => {
+  let registry: DomainRegistry;
+  let server: McpServer;
+  let tools: Map<string, RegisteredTool>;
+
+  beforeEach(() => {
+    registry = new DomainRegistry();
+    const built = makeServer();
+    server = built.server;
+    tools = built.tools;
+  });
+
+  describe("registerDomain", () => {
+    it("tracks every tool registered during the domain's registerTools call", () => {
+      const domain: DomainDefinition = {
+        name: "camera",
+        registerTools: (mcpServer) => {
+          mcpServer.registerTool(
+            "camera_fly_to",
+            {} as never,
+            (() => ({})) as never,
+          );
+          mcpServer.registerTool(
+            "camera_look_at",
+            {} as never,
+            (() => ({})) as never,
+          );
+        },
+      };
+
+      registry.registerDomain(domain, server, undefined);
+
+      const state = registry.getDomain("camera");
+      expect(state).toBeDefined();
+      expect(state?.enabled).toBe(true);
+      expect(state?.tools.size).toBe(2);
+      expect(state?.tools.has("camera_fly_to")).toBe(true);
+      expect(state?.tools.has("camera_look_at")).toBe(true);
+    });
+
+    it("restores the original registerTool after registration", () => {
+      const originalRegisterTool = server.registerTool;
+      const domain: DomainDefinition = {
+        name: "camera",
+        registerTools: (mcpServer) => {
+          mcpServer.registerTool("t1", {} as never, (() => ({})) as never);
+        },
+      };
+
+      registry.registerDomain(domain, server, undefined);
+
+      expect(server.registerTool).toBe(originalRegisterTool);
+    });
+
+    it("restores the original registerTool even when registration throws", () => {
+      const originalRegisterTool = server.registerTool;
+      const boom = new Error("boom");
+      const domain: DomainDefinition = {
+        name: "bad",
+        registerTools: () => {
+          throw boom;
+        },
+      };
+
+      expect(() => registry.registerDomain(domain, server, undefined)).toThrow(
+        boom,
+      );
+      expect(server.registerTool).toBe(originalRegisterTool);
+    });
+
+    it("does not cross-track tools between domains", () => {
+      const camera: DomainDefinition = {
+        name: "camera",
+        registerTools: (s) => {
+          s.registerTool("camera_one", {} as never, (() => ({})) as never);
+        },
+      };
+      const entity: DomainDefinition = {
+        name: "entity",
+        registerTools: (s) => {
+          s.registerTool("entity_one", {} as never, (() => ({})) as never);
+        },
+      };
+
+      registry.registerDomain(camera, server, undefined);
+      registry.registerDomain(entity, server, undefined);
+
+      expect(registry.getDomain("camera")?.tools.has("camera_one")).toBe(true);
+      expect(registry.getDomain("camera")?.tools.has("entity_one")).toBe(false);
+      expect(registry.getDomain("entity")?.tools.has("entity_one")).toBe(true);
+      expect(registry.getDomain("entity")?.tools.has("camera_one")).toBe(false);
+    });
+
+    it("passes the communicationServer argument through to the domain's registerTools", () => {
+      const commServer = {
+        executeCommand: vi.fn(),
+      } as unknown as ICommunicationServer;
+      const registerTools = vi.fn();
+      const domain: DomainDefinition = {
+        name: "camera",
+        registerTools,
+      };
+
+      registry.registerDomain(domain, server, commServer);
+
+      expect(registerTools).toHaveBeenCalledWith(server, commServer);
+    });
+  });
+
+  describe("disableDomain / enableDomain", () => {
+    const seedDomain = (name: string, toolNames: string[]) => {
+      const domain: DomainDefinition = {
+        name,
+        registerTools: (s) => {
+          for (const t of toolNames) {
+            s.registerTool(t, {} as never, (() => ({})) as never);
+          }
+        },
+      };
+      registry.registerDomain(domain, server, undefined);
+    };
+
+    it("calls disable() on every tool of the domain", () => {
+      seedDomain("camera", ["a", "b"]);
+      const result = registry.disableDomain("camera");
+
+      expect(result).toBe(true);
+      expect(registry.getDomain("camera")?.enabled).toBe(false);
+      expect(tools.get("a")?.disable).toHaveBeenCalledTimes(1);
+      expect(tools.get("b")?.disable).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls enable() on every tool when re-enabling", () => {
+      seedDomain("camera", ["a"]);
+      registry.disableDomain("camera");
+
+      const result = registry.enableDomain("camera");
+
+      expect(result).toBe(true);
+      expect(registry.getDomain("camera")?.enabled).toBe(true);
+      expect(tools.get("a")?.enable).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when disabling an already-disabled domain", () => {
+      seedDomain("camera", ["a"]);
+      registry.disableDomain("camera");
+
+      const result = registry.disableDomain("camera");
+
+      expect(result).toBe(true);
+      expect(tools.get("a")?.disable).toHaveBeenCalledTimes(1); // not twice
+    });
+
+    it("is a no-op when enabling an already-enabled domain", () => {
+      seedDomain("camera", ["a"]);
+      const result = registry.enableDomain("camera");
+
+      expect(result).toBe(true);
+      expect(tools.get("a")?.enable).not.toHaveBeenCalled();
+    });
+
+    it("returns false for unknown domain names", () => {
+      expect(registry.disableDomain("nope")).toBe(false);
+      expect(registry.enableDomain("nope")).toBe(false);
+    });
+  });
+
+  describe("listDomains / getDomainNames", () => {
+    it("returns an empty list when no domains are registered", () => {
+      expect(registry.listDomains()).toEqual([]);
+      expect(registry.getDomainNames()).toEqual([]);
+    });
+
+    it("returns a snapshot of every domain with enabled status and tool names", () => {
+      const camera: DomainDefinition = {
+        name: "camera",
+        registerTools: (s) => {
+          s.registerTool("a", {} as never, (() => ({})) as never);
+          s.registerTool("b", {} as never, (() => ({})) as never);
+        },
+      };
+      const entity: DomainDefinition = {
+        name: "entity",
+        registerTools: (s) => {
+          s.registerTool("c", {} as never, (() => ({})) as never);
+        },
+      };
+      registry.registerDomain(camera, server, undefined);
+      registry.registerDomain(entity, server, undefined);
+      registry.disableDomain("entity");
+
+      const list = registry.listDomains();
+
+      expect(list).toHaveLength(2);
+      expect(list[0]).toEqual({
+        name: "camera",
+        enabled: true,
+        toolCount: 2,
+        tools: ["a", "b"],
+      });
+      expect(list[1]).toEqual({
+        name: "entity",
+        enabled: false,
+        toolCount: 1,
+        tools: ["c"],
+      });
+      expect(registry.getDomainNames()).toEqual(["camera", "entity"]);
+    });
+  });
+});

--- a/mcp/cesium-js/servers/gateway/test/domains.test.ts
+++ b/mcp/cesium-js/servers/gateway/test/domains.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  ALL_DOMAINS,
+  VALID_DOMAIN_NAMES,
+  getEnabledDomains,
+} from "../src/domains";
+
+describe("domains", () => {
+  describe("ALL_DOMAINS", () => {
+    it("exposes the six expected domain definitions in a stable order", () => {
+      expect(ALL_DOMAINS.map((d) => d.name)).toEqual([
+        "camera",
+        "entity",
+        "animation",
+        "imagery",
+        "tiles",
+        "terrain",
+      ]);
+    });
+
+    it("every domain has a callable registerTools function", () => {
+      for (const domain of ALL_DOMAINS) {
+        expect(typeof domain.registerTools).toBe("function");
+      }
+    });
+  });
+
+  describe("VALID_DOMAIN_NAMES", () => {
+    it("matches ALL_DOMAINS.name in order", () => {
+      expect(VALID_DOMAIN_NAMES).toEqual(ALL_DOMAINS.map((d) => d.name));
+    });
+  });
+
+  describe("getEnabledDomains", () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+    });
+
+    it("returns ALL_DOMAINS when envValue is undefined", () => {
+      expect(getEnabledDomains(undefined)).toEqual(ALL_DOMAINS);
+    });
+
+    it("returns ALL_DOMAINS when envValue is an empty string", () => {
+      expect(getEnabledDomains("")).toEqual(ALL_DOMAINS);
+    });
+
+    it("returns ALL_DOMAINS when envValue is only whitespace", () => {
+      expect(getEnabledDomains("   ")).toEqual(ALL_DOMAINS);
+    });
+
+    it("filters by a single domain name", () => {
+      const result = getEnabledDomains("camera");
+      expect(result.map((d) => d.name)).toEqual(["camera"]);
+    });
+
+    it("filters by a comma-separated list", () => {
+      const result = getEnabledDomains("camera,entity,imagery");
+      expect(result.map((d) => d.name)).toEqual([
+        "camera",
+        "entity",
+        "imagery",
+      ]);
+    });
+
+    it("is case-insensitive", () => {
+      const result = getEnabledDomains("CAMERA, Entity");
+      expect(result.map((d) => d.name)).toEqual(["camera", "entity"]);
+    });
+
+    it("trims whitespace around each name", () => {
+      const result = getEnabledDomains(" camera ,  entity  ");
+      expect(result.map((d) => d.name)).toEqual(["camera", "entity"]);
+    });
+
+    it("skips empty items between commas", () => {
+      const result = getEnabledDomains("camera,,entity");
+      expect(result.map((d) => d.name)).toEqual(["camera", "entity"]);
+    });
+
+    it("preserves the canonical ALL_DOMAINS order regardless of input order", () => {
+      const result = getEnabledDomains("terrain,camera,imagery");
+      expect(result.map((d) => d.name)).toEqual([
+        "camera",
+        "imagery",
+        "terrain",
+      ]);
+    });
+
+    it("warns when unknown domain names are requested but still returns the valid ones", () => {
+      const result = getEnabledDomains("camera,bogus,entity");
+
+      expect(result.map((d) => d.name)).toEqual(["camera", "entity"]);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain("bogus");
+    });
+
+    it("returns an empty list when none of the names match", () => {
+      const result = getEnabledDomains("unknown1,unknown2");
+      expect(result).toEqual([]);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/mcp/cesium-js/servers/gateway/test/tools/discovery.test.ts
+++ b/mcp/cesium-js/servers/gateway/test/tools/discovery.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { DomainRegistry } from "../../src/domain-registry";
+import { registerDiscoveryTools } from "../../src/tools/discovery";
+
+type ToolHandler = (args?: Record<string, unknown>) =>
+  | {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }
+  | Promise<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>;
+
+describe("registerDiscoveryTools", () => {
+  let registry: DomainRegistry;
+  let server: { registerTool: ReturnType<typeof vi.fn> };
+  let handlers: Map<string, ToolHandler>;
+
+  beforeEach(() => {
+    registry = new DomainRegistry();
+    handlers = new Map();
+    server = {
+      registerTool: vi.fn(
+        (name: string, _config: unknown, handler: unknown) => {
+          handlers.set(name, handler as ToolHandler);
+        },
+      ),
+    };
+
+    // Seed two domains into the registry
+    registry.registerDomain(
+      {
+        name: "camera",
+        registerTools: (s) => {
+          s.registerTool("camera_fly_to", {} as never, (() => ({})) as never);
+          s.registerTool("camera_look_at", {} as never, (() => ({})) as never);
+        },
+      },
+      makeFakeMcpServer(),
+      undefined,
+    );
+    registry.registerDomain(
+      {
+        name: "entity",
+        registerTools: (s) => {
+          s.registerTool("entity_create", {} as never, (() => ({})) as never);
+        },
+      },
+      makeFakeMcpServer(),
+      undefined,
+    );
+
+    registerDiscoveryTools(server as unknown as McpServer, registry);
+  });
+
+  it("registers three tools: list, enable, disable", () => {
+    expect(server.registerTool).toHaveBeenCalledTimes(3);
+    const names = server.registerTool.mock.calls.map((c) => c[0]);
+    expect(names).toEqual([
+      "cesium_list_domains",
+      "cesium_enable_domain",
+      "cesium_disable_domain",
+    ]);
+  });
+
+  describe("cesium_list_domains", () => {
+    it("returns a summary containing every domain's name and tool count", async () => {
+      const handler = handlers.get("cesium_list_domains");
+      expect(handler).toBeDefined();
+
+      const result = await handler!();
+
+      expect(result.isError).toBeUndefined();
+      const text = result.content[0].text;
+      expect(text).toContain("camera");
+      expect(text).toContain("(2 tools)");
+      expect(text).toContain("entity");
+      expect(text).toContain("(1 tools)");
+      expect(text).toContain("Total: 2 domains, 3 tools");
+    });
+
+    it("reflects disabled status with [OFF]", async () => {
+      registry.disableDomain("entity");
+      const handler = handlers.get("cesium_list_domains")!;
+      const result = await handler();
+
+      expect(result.content[0].text).toContain("[ON] camera");
+      expect(result.content[0].text).toContain("[OFF] entity");
+    });
+  });
+
+  describe("cesium_disable_domain", () => {
+    it("disables an existing domain", async () => {
+      const handler = handlers.get("cesium_disable_domain")!;
+      const result = await handler({ domain: "camera" });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("camera");
+      expect(registry.getDomain("camera")?.enabled).toBe(false);
+    });
+
+    it("returns isError=true for an unknown domain", async () => {
+      const handler = handlers.get("cesium_disable_domain")!;
+      const result = await handler({ domain: "ghost" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("ghost");
+      expect(result.content[0].text).toContain("not found");
+    });
+  });
+
+  describe("cesium_enable_domain", () => {
+    it("re-enables a previously disabled domain", async () => {
+      registry.disableDomain("camera");
+      const handler = handlers.get("cesium_enable_domain")!;
+      const result = await handler({ domain: "camera" });
+
+      expect(result.isError).toBeUndefined();
+      expect(registry.getDomain("camera")?.enabled).toBe(true);
+      expect(result.content[0].text).toContain("camera");
+    });
+
+    it("returns isError=true for an unknown domain", async () => {
+      const handler = handlers.get("cesium_enable_domain")!;
+      const result = await handler({ domain: "ghost" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("ghost");
+    });
+  });
+});
+
+/**
+ * Small helper that returns a McpServer-shaped object whose registerTool
+ * yields a fresh tool stub every time — used for seeding the registry in tests.
+ */
+function makeFakeMcpServer(): McpServer {
+  return {
+    registerTool: vi.fn(() => ({
+      enabled: true,
+      enable: vi.fn(),
+      disable: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      handler: vi.fn(),
+    })),
+  } as unknown as McpServer;
+}

--- a/mcp/cesium-js/servers/gateway/tsconfig.json
+++ b/mcp/cesium-js/servers/gateway/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020"],
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@cesium-mcp/shared": ["../shared/src"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build"]
+}

--- a/mcp/cesium-js/servers/gateway/vitest.config.ts
+++ b/mcp/cesium-js/servers/gateway/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.ts"],
+      exclude: [
+        "**/*.test.ts",
+        "**/index.ts",
+        "**/*.d.ts",
+        "**/build/**",
+        "**/test/**",
+      ],
+    },
+  },
+  resolve: {
+    alias: {
+      "@cesium-mcp/shared": path.resolve(__dirname, "../shared/src"),
+    },
+  },
+});

--- a/mcp/cesium-js/servers/gateway/vitest.config.ts
+++ b/mcp/cesium-js/servers/gateway/vitest.config.ts
@@ -22,6 +22,30 @@ export default defineConfig({
   resolve: {
     alias: {
       "@cesium-mcp/shared": path.resolve(__dirname, "../shared/src"),
+      "@cesium-mcp/camera-server/tools": path.resolve(
+        __dirname,
+        "../camera-server/src/tools/index.ts",
+      ),
+      "@cesium-mcp/entity-server/tools": path.resolve(
+        __dirname,
+        "../entity-server/src/tools/index.ts",
+      ),
+      "@cesium-mcp/animation-server/tools": path.resolve(
+        __dirname,
+        "../animation-server/src/tools/index.ts",
+      ),
+      "@cesium-mcp/imagery-server/tools": path.resolve(
+        __dirname,
+        "../imagery-server/src/tools/index.ts",
+      ),
+      "@cesium-mcp/tiles-server/tools": path.resolve(
+        __dirname,
+        "../tiles-server/src/tools/index.ts",
+      ),
+      "@cesium-mcp/terrain-server/tools": path.resolve(
+        __dirname,
+        "../terrain-server/src/tools/index.ts",
+      ),
     },
   },
 });

--- a/mcp/cesium-js/servers/terrain-server/package.json
+++ b/mcp/cesium-js/servers/terrain-server/package.json
@@ -25,7 +25,8 @@
   ],
   "license": "Apache-2.0",
   "exports": {
-    ".": "./build/index.js"
+    ".": "./build/index.js",
+    "./tools": "./build/tools/index.js"
   },
   "dependencies": {
     "@cesium-mcp/shared": "workspace:*",

--- a/mcp/cesium-js/servers/tiles-server/package.json
+++ b/mcp/cesium-js/servers/tiles-server/package.json
@@ -26,7 +26,8 @@
   ],
   "license": "Apache-2.0",
   "exports": {
-    ".": "./build/index.js"
+    ".": "./build/index.js",
+    "./tools": "./build/tools/index.js"
   },
   "dependencies": {
     "@cesium-mcp/shared": "workspace:*",


### PR DESCRIPTION
# Unified MCP Gateway (`@cesium-mcp/gateway`)

This PR introduces `@cesium-mcp/gateway`, a new server that aggregates the tools from all existing domain servers (camera, entity, animation, imagery, tiles, terrain) behind a single MCP endpoint, and exposes meta-tools for runtime domain discovery and enable/disable.

Motivated by #35 — when many domain servers are connected at once, the active tool surface balloons and starts competing with the assistant's context budget. The gateway lets users start only the tools they need for the current task and flip others on as the conversation evolves, without restarting.

## Design

- `DomainRegistry` monkey-patches `mcpServer.registerTool` during each domain's `registerTools()` call (wrapped in `try/finally` so a throwing domain registration cannot permanently pollute the MCP server). The wrapper captures the returned `RegisteredTool` and stores it in a per-domain map.
- Three meta-tools are exposed:
  - `gateway_list_domains` — lists every domain with `[ON]` / `[OFF]` status and tool counts
  - `gateway_enable_domain` — calls `RegisteredTool.enable()` on every tool in a domain
  - `gateway_disable_domain` — calls `RegisteredTool.disable()` on every tool in a domain
  - The MCP SDK's `enable/disable` emits `listChanged` automatically, so the assistant's visible tool surface updates live.
- `GATEWAY_DOMAINS` environment variable controls which domains are enabled at boot (comma-separated, case-insensitive, whitespace-tolerant; unknown names log a warning; empty/unset means enable all).

## Sub-path exports

To let the gateway import each domain's tool-registration function without reaching into `build/`, every existing domain server now also declares a `"./tools"` subpath export that points at its `tools/index.ts` barrel. These barrels were already the de facto organisation — this PR only makes them part of the package API.

## Port

`3010` (next free slot after `3007` for terrain; leaves room for future domain servers).

## Tests

- `test/domain-registry.test.ts` (12) — monkey-patch capture, `try/finally` restore, cross-domain isolation, enable/disable idempotency, unknown-domain handling, snapshots
- `test/domains.test.ts` (14) — `getEnabledDomains` across undefined / empty / whitespace / case / trimming / unknown-warning / order-preservation
- `test/tools/discovery.test.ts` (7) — discovery tools registration, list formatting, enable/disable happy path, `isError` on unknown domain

Full monorepo suite: **1462 / 1462 passing** including the 33 new tests.

## Checklist

- [x] `pnpm run build` clean
- [x] `pnpm test` (all packages) — 1462 / 1462
- [x] ESLint clean on new code
- [x] Prettier clean on new code
- [x] README updated — gateway row in packages table, new tool table, `GATEWAY_DOMAINS` note, structure tree, build/dev scripts, MCP client config block
- [x] `.env.example` shipped
- [x] Unit tests shipped

Refs #35
